### PR TITLE
add GenBs and GenHs, restructure GenAnalyzer, clean HHAnalyzer

### DIFF
--- a/plugins/GenAnalyzer.h
+++ b/plugins/GenAnalyzer.h
@@ -32,6 +32,7 @@ class GenAnalyzer {
         virtual reco::Candidate* FindLastDaughter(reco::Candidate*);
         virtual reco::GenParticle* FindGenParticleGenByIds(std::vector<reco::GenParticle>&, std::vector<int>, int=-1);
         virtual reco::GenParticle* FindLastDaughterGen(reco::GenParticle*);
+        virtual const reco::GenParticle* FindLastDaughterGen(const reco::GenParticle*);
         virtual const reco::Candidate* FindMother(reco::GenParticle*);
         virtual reco::Candidate* FindGenParticleByIdAndStatus(std::vector<reco::GenParticle>&, int, int);
         virtual float GetStitchWeight(std::map<std::string, float>);
@@ -40,6 +41,8 @@ class GenAnalyzer {
         virtual float GetPUWeight(const edm::Event&);
     //    virtual float GetPDFWeight(const edm::Event&);
         virtual std::pair<float, float> GetQ2Weight(const edm::Event&);
+        virtual std::vector<reco::GenParticle> PartonsFromDecays(const std::vector<int> & pdgIds);
+        virtual std::vector<reco::GenParticle> PartonsFromDecays(const std::vector<int> & pdgIds, std::vector<reco::GenParticle> & genDecay );
 
       
     private:
@@ -67,6 +70,10 @@ class GenAnalyzer {
         TF1* fWEWK;
         
         edm::LumiReWeighting* LumiWeights;
+
+        // new member to hold GenCollection and about copy overheads
+        edm::Handle<std::vector<reco::GenParticle> > GenCollection;
+
 };
 
 

--- a/plugins/HHAnalyzer.cc
+++ b/plugins/HHAnalyzer.cc
@@ -87,7 +87,7 @@ HHAnalyzer::HHAnalyzer(const edm::ParameterSet& iConfig):
         }
     }
     histFile.close();
-    
+
     std::cout << "---------- STARTING ----------" << std::endl;
 }
 
@@ -220,18 +220,9 @@ void HHAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     
     EventWeight *= ZewkWeight * WewkWeight;
 
-    std::vector<int> LepIds = {12,14,16,-12,-14,-16};
-    std::vector<int> HadIds = {1,2,3,4,5,-1,-2,-3,-4,-5};
-    reco::GenParticle* theGenLep = theGenAnalyzer->FindGenParticleGenByIds(GenPVect, LepIds);
-    reco::GenParticle* theGenHad = theGenAnalyzer->FindGenParticleGenByIds(GenPVect, HadIds);
-    
-    //Gen level plots and candidates
-    double GenHadDR = -9.;
-    double GenLepDR = -9.;
-    //double GenZHadFatJetDR = -9.;
-    bool isGenZZ = false;
-    reco::Particle::LorentzVector p4GenZHad;
-    //add for genH / genHH    
+    std::vector<reco::GenParticle> GenHsPart;
+    std::vector<reco::GenParticle> GenBFromHsPart = theGenAnalyzer->PartonsFromDecays({25}, GenHsPart);
+
 
     // ---------- Trigger selections ----------
     Hist["a_nEvents"]->Fill(2., EventWeight);
@@ -287,6 +278,19 @@ void HHAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     auto cmva_comp = [&](std::size_t a, std::size_t b) {return Jets.at(a).CMVA > Jets.at(b).CMVA;};
     std::sort(j_sort_cmva.begin(), j_sort_cmva.end(), cmva_comp);
 
+    // fill b quarks from higgs
+    GenBFromHs.clear();
+    for(unsigned int i = 0; i < GenBFromHsPart.size(); i++) {
+      GenBFromHs.emplace_back();
+      ObjectsFormat::FillLorentzType(GenBFromHs[i], &GenBFromHsPart.at(i).p4());
+    }
+
+    // fill b quarks from higgs
+    GenHs.clear();
+    for(unsigned int i = 0; i < GenHsPart.size(); i++) {
+      GenHs.emplace_back();
+      ObjectsFormat::FillLorentzType(GenHs[i], &GenHsPart.at(i).p4());
+    }
     
     // Fill tree
     tree->Fill();
@@ -354,6 +358,8 @@ void HHAnalyzer::beginJob() {
     tree->Branch("Jets", &(Jets), 64000, 2);
     for(int i = 0; i < WriteNFatJets; i++) tree->Branch(("FatJet"+std::to_string(i+1)).c_str(), &(FatJets[i].pt), ObjectsFormat::ListFatJetType().c_str());
     tree->Branch("MEt", &MEt.pt, ObjectsFormat::ListMEtType().c_str());
+    tree->Branch("GenBFromHs", &(GenBFromHs), 64000, 2);
+    tree->Branch("GenHs", &(GenHs), 64000, 2);
 
     tree->Branch("j_sort_pt", &(j_sort_pt), 64000, 2);
     tree->Branch("j_sort_csv", &(j_sort_csv), 64000, 2);

--- a/plugins/HHAnalyzer.h
+++ b/plugins/HHAnalyzer.h
@@ -166,7 +166,8 @@ class HHAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
         std::vector<JetType> Jets;
         std::vector<FatJetType> FatJets;
         MEtType MEt;
-        std::vector<CandidateType> GenHs;
+        std::vector<LorentzType> GenBFromHs;
+        std::vector<LorentzType> GenHs;
 
         // for saving jet sortings
         std::vector<std::size_t> j_sort_pt;

--- a/src/classes.h
+++ b/src/classes.h
@@ -12,5 +12,7 @@ namespace {
     std::vector<JetType> dummy4;
     std::vector<LeptonType> dummy5;
     std::vector<std::size_t> dummy6;
+    LorentzType dummy7;
+    std::vector<LorentzType> dummy8;
   };
 }

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -1,8 +1,10 @@
 
 <lcgdict>
+  <class name="LorentzType"/>
   <class name="CandidateType"/>
   <class name="JetType"/>
   <class name="LeptonType"/>
+  <class name="std::vector<LorentzType>"/>
   <class name="std::vector<CandidateType>"/>
   <class name="std::vector<JetType>"/>
   <class name="std::vector<LeptonType>"/>


### PR DESCRIPTION
Added GenHs and GenBs as branches in the output TTree for the HHAnalysis, which are very useful to study pairing and do regression studies. Need to add dictionary generation for the LorentzVector class.
I have added the GenCollection vector (edm::Handle) as a member of the class HHAnalyzer. However the copy overhead is still there to keep compatibility with use on Diboson analysis.
